### PR TITLE
Remove mention of forking, so that git-collaborative isn't a dependency.

### DIFF
--- a/_episodes/03-workflow-management.md
+++ b/_episodes/03-workflow-management.md
@@ -95,9 +95,9 @@ Let's look at an example project which follows the project structure guidelines 
 The project is about counting the frequency distribution of words in a given text, plotting bar charts and testing 
 [Zipf's law](https://en.wikipedia.org/wiki/Zipf%27s_law).
 
-> To follow along, **fork and clone** this [repository](https://github.com/coderefinery/word-count):
+> To follow along, clone this [repository](https://github.com/coderefinery/word-count):
 > ```shell
-> $ git clone https://github.com/user/word-count.git
+> $ git clone https://github.com/coderefinery/word-count.git
 > ```
 
 The example project directory is like this:


### PR DESCRIPTION
- Just have them directly clone the coderefinery repository.
- As discussed in #58 and coderefinery/git-intro#157.
- Closes: #58
- Other lessons will have to be updated to have students remove the
  word-count repo if it's already cloned (maybe here too?).