### PR TITLE
Docker general and practical

### DIFF
--- a/_episodes/01-motivation.md
+++ b/_episodes/01-motivation.md
@@ -67,6 +67,8 @@ domains of science:
 
 ## Reproducible, replicable, robust, generalisable
 
+While reproducibility is the minimum requirement and can be solved with "good enough" computational practices, replicability/robustness/generalisability of scientific findings are an even greater concern involving research misconduct, questionable research practices (p-hacking, HARKing, cherry-picking), sloppy methods, and other conscious and unconscious biases. 
+
 <img src="{{ site.baseurl }}/img/turing-way/39-reproducible-replicable-robust-generalisable.jpg" style="width: 700px;"/>
 
 (This image was created by [Scriberia](http://www.scriberia.co.uk) for [The

--- a/_episodes/05-environments.md
+++ b/_episodes/05-environments.md
@@ -33,6 +33,22 @@ questions:
   </p>
 </div>
 
+#### Examples of useful Docker images
+1) Run a specific version of *Rstudio* 
+
+`docker run --rm -p 8787:8787 -e PASSWORD=yourpasswordhere rocker/rstudio`
+
+Then open your browser to `http://localhost:8787` with login rstudio and password "yourpasswordhere" used in the previous command.
+If you want to try an older version you can check the tags at https://hub.docker.com/r/rocker/rstudio/tags and run for example
+
+`docker run --rm -p 8787:8787 -e PASSWORD=yourpasswordhere rocker/rstudio:3.3`
+
+2) Run a specific version of *Anaconda3* https://hub.docker.com/r/continuumio/anaconda3
+
+`docker run -i -t continuumio/anaconda3 /bin/bash`
+
+and similarly one can also pick an image for *Anaconda2* https://hub.docker.com/r/continuumio/anaconda2/tags
+
 
 ### Singularity
 

--- a/_episodes/05-environments.md
+++ b/_episodes/05-environments.md
@@ -38,16 +38,16 @@ questions:
 
 `docker run --rm -p 8787:8787 -e PASSWORD=yourpasswordhere rocker/rstudio`
 
-Then open your browser to `http://localhost:8787` with login rstudio and password "yourpasswordhere" used in the previous command.
-If you want to try an older version you can check the tags at https://hub.docker.com/r/rocker/rstudio/tags and run for example
+Then open your browser to [http://localhost:8787](http://localhost:8787) with login rstudio and password "yourpasswordhere" used in the previous command.
+If you want to try an older version you can check the tags at [https://hub.docker.com/r/rocker/rstudio/tags](https://hub.docker.com/r/rocker/rstudio/tags) and run for example
 
 `docker run --rm -p 8787:8787 -e PASSWORD=yourpasswordhere rocker/rstudio:3.3`
 
-2) Run a specific version of *Anaconda3* https://hub.docker.com/r/continuumio/anaconda3
+2) Run a specific version of *Anaconda3* from [https://hub.docker.com/r/continuumio/anaconda3](https://hub.docker.com/r/continuumio/anaconda3)
 
 `docker run -i -t continuumio/anaconda3 /bin/bash`
 
-and similarly one can also pick an image for *Anaconda2* https://hub.docker.com/r/continuumio/anaconda2/tags
+and similarly one can also pick an image for *Anaconda2* at [https://hub.docker.com/r/continuumio/anaconda2/tags](https://hub.docker.com/r/continuumio/anaconda2/tags)
 
 
 ### Singularity

--- a/_episodes/07-docker.md
+++ b/_episodes/07-docker.md
@@ -208,3 +208,14 @@ $ docker push docker.io/YOURUSER/word_count
   ```
 
 - For proprietary/sensitive images private Docker registries can be used
+- Sometimes you don't want to push the image but you want to freeze it locally
+
+ ```shell
+$ docker save word_count > word_count_0.1.tar
+ ```
+
+and then you can reload it with
+
+ ```shell
+$ docker load --input word_count_0.1.tar
+ ```

--- a/_episodes/07-docker.md
+++ b/_episodes/07-docker.md
@@ -199,11 +199,9 @@ We can also specify snakemake (or  any other command) as the default command to 
 $ docker login
   ```
 - Push to DockerHub. The image name has to be in **youruser/yourimage** format:
+ 
  ```shell
 $ docker tag TAGID YOURUSER/word_count
- ```
-
- ```shell
 $ docker push docker.io/YOURUSER/word_count
   ```
 

--- a/_episodes/07-docker.md
+++ b/_episodes/07-docker.md
@@ -107,11 +107,11 @@ LABEL maintainer="kthw@kth.se"
 # update the apt package manager
 RUN apt-get update
 RUN apt-get install -y software-properties-common
-RUN add-apt-repository ppa:deadsnakes/python-3.6
-RUN apt-get update
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update && apt-get -y install locales
 
 # install make
-RUN apt-get install -y build-essential
+RUN apt-get install -y build-essential 
 
 # install nano
 RUN apt-get install -y nano

--- a/_episodes/07-docker.md
+++ b/_episodes/07-docker.md
@@ -107,7 +107,7 @@ LABEL maintainer="kthw@kth.se"
 # update the apt package manager
 RUN apt-get update
 RUN apt-get install -y software-properties-common
-RUN add-apt-repository ppa:jonathonf/python-3.6
+RUN add-apt-repository ppa:deadsnakes/python-3.6
 RUN apt-get update
 
 # install make
@@ -118,6 +118,7 @@ RUN apt-get install -y nano
 
 # install python
 RUN apt-get install -y python3.6 python3.6-dev python3-pip python3.6-venv
+RUN pip3 install --upgrade pip
 RUN yes | pip3 install numpy
 RUN yes | pip3 install matplotlib
 RUN yes | pip3 install snakemake
@@ -197,11 +198,13 @@ We can also specify snakemake (or  any other command) as the default command to 
  ```shell
 $ docker login
   ```
-- Push to DockerHub. The image name has to be in **youruser/yourimage** format
-(thus instead of the name `word_count`,
-we should have used `<dockerhub-username>/word_count` above):
+- Push to DockerHub. The image name has to be in **youruser/yourimage** format:
+ ```shell
+$ docker tag TAGID YOURUSER/word_count
+ ```
 
  ```shell
-$ docker push image_name
+$ docker push docker.io/YOURUSER/word_count
   ```
+
 - For proprietary/sensitive images private Docker registries can be used

--- a/index.md
+++ b/index.md
@@ -11,8 +11,6 @@ control, workflows, containers, and package managers can be used to record
 reproducible environments and computational steps.
 
 
-
-
 > ## Prerequisites
 >
 > 1. You need to install [Git, Python, and Snakemake](https://coderefinery.github.io/installation/).

--- a/index.md
+++ b/index.md
@@ -11,6 +11,8 @@ control, workflows, containers, and package managers can be used to record
 reproducible environments and computational steps.
 
 
+
+
 > ## Prerequisites
 >
 > 1. You need to install [Git, Python, and Snakemake](https://coderefinery.github.io/installation/).


### PR DESCRIPTION
In _episodes/05-environments.md I have added some practical usage of other's docker images (e.g. to run Rstudio without installing it or to run older version of anaconda without touching local install)

In _episodes/07-docker.md I have edited the Dockerfile example to reflect the changes that were needed to make it build. I have also added at the end some examples to push to dockerhub but also to store the image locally into a tar file (and how to reload it) when the content is sensitive.