### PR TITLE
move make section into separate file

### DIFF
--- a/_episodes/05-environments.md
+++ b/_episodes/05-environments.md
@@ -72,8 +72,9 @@ important problems:
 - Allow for seamlessly moving workflows across different platforms.
 - Much more lightweight than virtual machines.
 - Eliminates the "works on my machine" situation.
-- For software with many dependencies with it turn own dependencies possibly the only (?) way
-  to preserve the computational experiment for future reproducibility.
+- For software with many dependencies, in turn with its own dependencies,
+  containers offer possibly the only way to preserve the
+  computational experiment for future reproducibility.
 
 However, containers may also have some drawbacks:
 - Containers can have security vulnerabilities which can be exploited.

--- a/_episodes/06-workflow-management.md
+++ b/_episodes/06-workflow-management.md
@@ -12,11 +12,11 @@ objectives:
 keypoints:
   - Preserve the steps for re-generating published results.
   - Hundreds of workflow management tools exist.
-  - Make and Snakemake are a comparatively simple and lightweight options to create transferable and scalable data analyses.
+  - Snakemake is a comparatively simple and lightweight option to create transferable and scalable data analyses.
   - Sometimes a script is enough.
 ---
 
-## One problem solved in 5 different ways
+## One problem solved in 4 different ways
 
 > The following material is adapted from a [HPC Carpentry lesson](https://hpc-carpentry.github.io/hpc-python/)
 
@@ -72,7 +72,7 @@ Can you relate? Are you using similar setups in your research?
 
 This was for one book - how about 3 books? How about 3000 books?
 
-**We will solve this solved in 5 different ways and discuss pros and cons.**
+**We will solve this in four different ways and discuss pros and cons.**
 
 ---
 
@@ -162,108 +162,11 @@ This is still **imperative style**: we tell the script to run these steps in pre
 
 ---
 
-## Solution 4: Using [GNU Make](https://www.gnu.org/software/make/)
+## Solution 4: Using [Snakemake](https://snakemake.readthedocs.io/en/stable/index.html)
 
-First study the `Makefile`:
-```makefile
-# directory containing source data
-SRCDIR := data
-
-# directory containing intermediate data
-TMPDIR := processed_data
-
-# results directory
-RESDIR := results
-
-# all source files (book texts)
-SRCS = $(wildcard $(SRCDIR)/*.txt)
-
-# all intermediate data files
-DATA = $(patsubst $(SRCDIR)/%.txt,$(TMPDIR)/%.dat,$(SRCS))
-
-# all images
-IMAGES = $(patsubst $(SRCDIR)/%.txt,$(RESDIR)/%.png,$(SRCS))
-
-all: $(DATA) $(IMAGES) $(RESDIR)/results.txt
-
-$(TMPDIR)/%.dat: $(SRCDIR)/%.txt source/wordcount.py
-        python source/wordcount.py $< $@
-
-$(RESDIR)/%.png: $(TMPDIR)/%.dat source/plotcount.py
-        python source/plotcount.py $< $@
-
-$(RESDIR)/results.txt: $(DATA) source/zipf_test.py
-        python source/zipf_test.py $(DATA) > $@
-
-clean:
-        @$(RM) $(TMPDIR)/*
-        @$(RM) $(RESDIR)/*
-
-.PHONY: clean directories
-```
-
-- A tool from the 70s often used to build software.
-- Uses specific syntax that the user writes in a Makefile.
-- Makefile specifies how to build targets from their dependencies.
-- Observe that we use wildcards instead of explicit book names.
-
-It contains rules that relate targets to dependencies and commands:
-
-```makefile
-# rule (mind the tab)
-target: dependencies
-	command(s)
-```
-
-We can think of it as follows:
-```makefile
-outputs: inputs
-	command(s)
-```
-
-Try it out:
-```
-$ make clean
-$ make
-```
-
-Make uses **declarative style**: we describe dependencies but we let Make
-figure out the series of steps to produce results (targets). Fun fact: Excel is also
-declarative, not imperative.
-
-Try running `make` again and discuss why it refused to rerun all steps:
-```
-$ make
-
-make: Nothing to be done for 'all'.
-```
-
-Make a modification to a txt or a dat file and run `make` again and discuss
-what you see. One way to modify files is to use the `touch` command which will
-only update its timestamp:
-
-```
-$ touch data/sierra.txt
-$ make
-```
-
-How did Make know which steps to rerun?
-
-Finally try to run the pipeline on several cores in parallel (here we will try 4):
-
-```
-$ make clean
-$ make -j 4
-```
-
-> ## Discussion
->
-> Discuss the pros and cons of this approach. Is it reproducible? Does it scale to hundreds of books? Can it be automated?
-{: .challenge}
-
----
-
-## Solution 5: Using [Snakemake](https://snakemake.readthedocs.io/en/stable/index.html)
+Snakemake is inspired by [GNU Make](https://www.gnu.org/software/make/),
+but based on Python and is more general and has easier syntax.
+The workflow below can also be [implemented using make](../make-alternative).
 
 First study the `Snakefile`:
 

--- a/_episodes/make-alternative.md
+++ b/_episodes/make-alternative.md
@@ -1,0 +1,104 @@
+---
+layout: default
+---
+
+## Solution 5: Using [GNU Make](https://www.gnu.org/software/make/)
+
+First study the `Makefile`:
+```makefile
+# directory containing source data
+SRCDIR := data
+
+# directory containing intermediate data
+TMPDIR := processed_data
+
+# results directory
+RESDIR := results
+
+# all source files (book texts)
+SRCS = $(wildcard $(SRCDIR)/*.txt)
+
+# all intermediate data files
+DATA = $(patsubst $(SRCDIR)/%.txt,$(TMPDIR)/%.dat,$(SRCS))
+
+# all images
+IMAGES = $(patsubst $(SRCDIR)/%.txt,$(RESDIR)/%.png,$(SRCS))
+
+all: $(DATA) $(IMAGES) $(RESDIR)/results.txt
+
+$(TMPDIR)/%.dat: $(SRCDIR)/%.txt source/wordcount.py
+        python source/wordcount.py $< $@
+
+$(RESDIR)/%.png: $(TMPDIR)/%.dat source/plotcount.py
+        python source/plotcount.py $< $@
+
+$(RESDIR)/results.txt: $(DATA) source/zipf_test.py
+        python source/zipf_test.py $(DATA) > $@
+
+clean:
+        @$(RM) $(TMPDIR)/*
+        @$(RM) $(RESDIR)/*
+
+.PHONY: clean directories
+```
+
+- A tool from the 70s often used to build software.
+- Uses specific syntax that the user writes in a Makefile.
+- Makefile specifies how to build targets from their dependencies.
+- Observe that we use wildcards instead of explicit book names.
+
+It contains rules that relate targets to dependencies and commands:
+
+```makefile
+# rule (mind the tab)
+target: dependencies
+	command(s)
+```
+
+We can think of it as follows:
+```makefile
+outputs: inputs
+	command(s)
+```
+
+Try it out:
+```
+$ make clean
+$ make
+```
+
+Make uses **declarative style**: we describe dependencies but we let Make
+figure out the series of steps to produce results (targets). Fun fact: Excel is also
+declarative, not imperative.
+
+Try running `make` again and discuss why it refused to rerun all steps:
+```
+$ make
+
+make: Nothing to be done for 'all'.
+```
+
+Make a modification to a txt or a dat file and run `make` again and discuss
+what you see. One way to modify files is to use the `touch` command which will
+only update its timestamp:
+
+```
+$ touch data/sierra.txt
+$ make
+```
+
+How did Make know which steps to rerun?
+
+Finally try to run the pipeline on several cores in parallel (here we will try 4):
+
+```
+$ make clean
+$ make -j 4
+```
+
+> ## Discussion
+>
+> Discuss the pros and cons of this approach. Is it reproducible? Does it scale to hundreds of books? Can it be automated?
+{: .challenge}
+
+---


### PR DESCRIPTION
the episode is a bit too long and confusing with both make and snakemake.
But the make section might be interesting to some participants, and can be an alternative in case someone's snakemake installation has failed, so it's kept in a separate file