### PR TITLE
Add hint on `touch` command in exercise

### DIFF
--- a/_episodes/06-workflow-management.md
+++ b/_episodes/06-workflow-management.md
@@ -288,9 +288,11 @@ Rules that have yet to be completed are indicated with solid outlines, while alr
 >
 > - Start by cleaning all output, and run snakemake.
 >   How many jobs are run?
-> - Try "touching" the file `data/sierra.txt` and rerun snakemake.
+> - Try "touching" the file `data/sierra.txt` and rerun snakemake
+>   (`touch data/sierra.txt`).
 >   Which steps of the workflow are run now, and why?
-> - Now touch the file `processed_data/sierra.dat`, and run
+> - Now touch the file `processed_data/sierra.dat` to update the
+>   timestamp, and run
 >   `snakemake -S`. Can you make sense of the output?
 > - Rerun snakemake. Which steps are run, and why?
 > - Finally try touching `source/wordcount.py` and rerun snakemake.


### PR DESCRIPTION
- It's not actually needed because it's presented above, but if
  someone doesn't read carefully they might not pick it up and
  remember it.