### PR TITLE
windows equivalent for touch added

### DIFF
--- a/_episodes/05-workflow-management.md
+++ b/_episodes/05-workflow-management.md
@@ -377,14 +377,16 @@ rule NAME:
 
 > ## Exercise using Snakemake
 >
-> - Start by cleaning all output, and run snakemake.
+> - Start by cleaning all output, and run snakemake 
+>   (`snakemake`, you may have to add `-j 1` to the call).
 >   How many jobs are run?
-> - Try "touching" the file `data/sierra.txt` and rerun snakemake
->   (`touch data/sierra.txt`).
->   Which steps of the workflow are run now, and why?
+> - Try "touching" the file `data/sierra.txt` (`touch data/sierra.txt` 
+>   (unix/git bash) or `copy /b data\sierra.txt +,,` (windows cmd /anaconda prompt) ) 
+>   and rerun snakemake.
+>   Which steps of the workflow are run now, and why? 
 > - Now touch the file `processed_data/sierra.dat` to update the
 >   timestamp, and run
->   `snakemake -S`. Can you make sense of the output?
+>   `snakemake -S` (-S stands for summary). Can you make sense of the output?
 > - Rerun snakemake. Which steps are run, and why?
 > - Finally try touching `source/wordcount.py` and rerun snakemake.
 >   Which steps are run, and why? Should source codes be considered


### PR DESCRIPTION
Moi,

Tried to fix my own issue (#133 ) here, since in the breakoutroom I was in, there was a lot of confusion about what to use as windows user. Hope it is useful for future courses :) 
The title of this pull request is misleading in a way that it does not actually do all that touch does, but it updates the timestamp, which is the functionality needed in this exercise.
I do not know if this is a good way of doing it in windows,  but it is a way that works ( in cmd and anaconda promt, for some reason not in powershell, should that also be added somewhere?) . Please also test this before merging and also confirm: the /b should maybe be removed from the command, but this is unclear to me, if it might actually be useful in this example?

I also do not know if the '-j 1' needs to always be added to the snakemake call, but for me (on ubuntu) it's saying I have to.

Another way of fixing the issue would be to add solutions to this exercise, as in 'what should be observed after each step', this would also help the helpers, see issue #132  ?

-Samantha