### PR TITLE
remove TSD from 06-sharing.md

### DIFF
--- a/_episodes/06-sharing.md
+++ b/_episodes/06-sharing.md
@@ -143,7 +143,6 @@ platform and filter by country, content type, discipline, etc.
 
 - [NIRD archive is widely used by some communities](https://archive.norstore.no/)
 - [NSD - Norwegian Center for Research Data, for any kind of data](https://nsd.no/nsd/english/index.html)
-- [TSD - Norwegian Service for Sensitive Data](https://www.uio.no/english/services/it/research/sensitive-data/about/index.html)
 - [Dataverse.no - Dataverse network, based at University of Tromsø but open for other institutions](https://dataverse.no/)
 
 **Denmark:**


### PR DESCRIPTION
I would suggest to remove TSD from 06-sharing.md as it is not a data deposition repository but a environment for computing of sensitive data