### PR TITLE
Clarify first step in snakemake exercise

### DIFF
--- a/_episodes/04-workflow-management.md
+++ b/_episodes/04-workflow-management.md
@@ -369,6 +369,7 @@ Rules that have yet to be completed are indicated with solid outlines, while alr
 ---
 > ## Exercise using Snakemake
 >
+> Having followed the [exercise preparation](https://coderefinery.github.io/reproducible-research/04-workflow-management/#exercise-preparation), make sure that you are in the `word-count` repository.
 > 1. Start by cleaning all output with `snakemake --delete-all-output`, and run
 >   `snakemake` (you may have to add `-j 1` to the calls).
 >   How many jobs are run?


### PR DESCRIPTION
**Motivation:** Several learners (and helpers) who start the snakemake exercise by directly following the [exercise link](https://coderefinery.github.io/reproducible-research/04-workflow-management/#exercise-using-snakemake) get stuck because not being in the correct folder.

**Solution:** As a first step, clarify that the user needs to be in the correct folder/repo.