### PR TITLE
Exercises renamed and Mamba added

### DIFF
--- a/content/dependencies.md
+++ b/content/dependencies.md
@@ -41,9 +41,11 @@ that you know your dependencies!
 
 (different-solutions-to-specify-requirements)=
 
-## Different solutions to specify requirements
+## Exercise - Different solutions to specify requirements
 
-````{challenge} Compare these four requirements.txt 
+````{challenge} Dependencies-1: Comparing requirements
+Compare these four requirements.txt 
+
 **A**:
 
 Code depends on a number of packages but there is no `requirements.txt` file or equivalent.
@@ -206,9 +208,9 @@ A step-by-step guide on how to contribute packages can be found in the
 
 (exploring-conda-environments)=
 
-## Exploring conda environments
+## Exercise - Exploring conda environments
 
-```{exercise} Working with conda
+```{exercise} Dependencies-2: Working with conda
 - Inspect your available environments with `conda info -e`.
 - Deactivate the current environment with `conda deactivate`.
 - Use `conda activate base` to change to the base environment.

--- a/content/dependencies.md
+++ b/content/dependencies.md
@@ -260,6 +260,8 @@ A step-by-step guide on how to contribute packages can be found in the
   - Alternative to virtualenv and Pipenv
 - [Pyenv](https://github.com/pyenv/pyenv)
   - Tool to easily manage per-project/per-directory Python **versions**
+- [Mamba](https://github.com/mamba-org/mamba)
+  - works like conda, but resolves dependencies faster 
 
 
 ### R

--- a/content/environments.md
+++ b/content/environments.md
@@ -103,6 +103,7 @@ However, containers may also have some drawbacks:
 ```
 
 ---
+## Exercise - Play with Docker
 
 `````{exercise} (Optional) Play with Docker
 1. This exercise requires a DockerHub account. You can sign up on [https://hub.docker.com/signup](https://hub.docker.com/signup).

--- a/content/environments.md
+++ b/content/environments.md
@@ -105,7 +105,7 @@ However, containers may also have some drawbacks:
 ---
 ## Exercise - Play with Docker
 
-`````{exercise} (Optional) Play with Docker
+`````{exercise} (Optional) Environment-1: Play with Docker
 1. This exercise requires a DockerHub account. You can sign up on [https://hub.docker.com/signup](https://hub.docker.com/signup).
 2. Go to [Play with Docker](https://labs.play-with-docker.com/) and log in using 
    your DockerHub account. 

--- a/content/motivation.md
+++ b/content/motivation.md
@@ -19,7 +19,7 @@
 :width: 100%
 ```
 
-```{discussion} A scary anecdote
+```{instructor-note} A scary anecdote
 - A group of researchers obtain great results and submit their work to a high-profile journal.
 - Reviewers ask for new figures and additional analysis.
 - The researchers start working on revisions and generate modified figures, but find inconsistencies with old figures.
@@ -104,7 +104,7 @@ Turing Way](https://the-turing-way.netlify.com) community and is used under a
 CC-BY licence. The image was obtained from [https://zenodo.org/record/3332808](https://zenodo.org/record/3332808).)
 
 
-```{challenge} Discuss with your neighbors or among all participants
+```{discussion} Discuss with your neighbors or among all participants
 Computer programs are expected to produce the same
 output for the same inputs. Is
 that true for research software?

--- a/content/motivation.md
+++ b/content/motivation.md
@@ -19,7 +19,7 @@
 :width: 100%
 ```
 
-```{instructor-note} A scary anecdote
+```{note} A scary anecdote
 - A group of researchers obtain great results and submit their work to a high-profile journal.
 - Reviewers ask for new figures and additional analysis.
 - The researchers start working on revisions and generate modified figures, but find inconsistencies with old figures.

--- a/content/organizing-projects.md
+++ b/content/organizing-projects.md
@@ -92,7 +92,7 @@ $ git tag -a thesis-submitted -m "this is the submitted version of my thesis"
 
 (an-example-project)=
 
-## An example project
+## Exercise : Word count - An example project
 
 ````{challenge} Word count
 Let's look at an [example project](https://github.com/coderefinery/word-count) 

--- a/content/organizing-projects.md
+++ b/content/organizing-projects.md
@@ -94,7 +94,7 @@ $ git tag -a thesis-submitted -m "this is the submitted version of my thesis"
 
 ## Exercise : Word count - An example project
 
-````{challenge} Word count
+````{challenge} Project organization-1: Word count
 Let's look at an [example project](https://github.com/coderefinery/word-count) 
 which follows the project structure guidelines given above. 
 

--- a/content/sharing.md
+++ b/content/sharing.md
@@ -98,10 +98,9 @@ Note that FAIR principles do not require data/software to be open.
 
 (connecting-repositories-to-zenodo)=
 
-## Connecting repositories to Zenodo
+## Exercise - Connecting repositories to Zenodo
  
-```{exercise} Get a DOI by connecting your repository to Zenodo
-
+```{exercise} Sharing-1: Get a DOI from Zenodo
 Digital object identifiers (DOI) are the backbone of the academic
 reference and metrics system. In this exercise we will see how to
 make a GitHub repository citable by archiving it on the

--- a/content/workflow-management.md
+++ b/content/workflow-management.md
@@ -336,9 +336,9 @@ Discuss the pros and cons of these different approaches. Which are reproducible?
 
 (using-snakemake)=
 
-### Using Snakemake
+### Exercise - Using Snakemake
 
-````{exercise} Exercise using Snakemake
+````{exercise} Workflow-1: Using Snakemake
 Having followed the "Exercise preparation" above, make sure that you are in the `word-count` repository.
 
 1. Start by cleaning all output with `snakemake --delete-all-output`. 
@@ -421,9 +421,9 @@ Having followed the "Exercise preparation" above, make sure that you are in the 
 
 (snakemake-with-conda-environments)=
 
-### Snakemake with conda environments
+### Exercise - Snakemake with conda environments
 
-`````{exercise} (Optional) Using Snakemake with conda environments
+`````{exercise} (Optional) Workflow-2: Snakemake and Conda
 
 Let's say that the `make_plot` rule, which runs the 
 `source/plotcount.py` script, requires a separate 
@@ -476,9 +476,9 @@ software environment.
 
 (snakemake-in-hpc)=
 
-### Snakemake in HPC
+### Exercise - Snakemake on High Performance Computers
 
-````{exercise} (Optional) using Snakemake on HPC
+````{exercise} (Optional) Workflow-3: Snakemake on HPC
 - On a cluster node, Snakemake uses as many cores as available on that node. If a program that is run in a rule can only run efficiently up to a given number of CPU threads, it's possible to manually set a maximum in the rule definition:
 ```
 rule count_words:


### PR DESCRIPTION
closes #177 , #179
* exchange one exercise to discussion box in motivation
* put anecdote in note box instead of discussion
* renamed all exercises to comply with https://coderefinery.org/sphinx-lesson/exercise-list/#recommendations-to-make-a-useful-list
* added headers above exercises that did not have one
* added Mamba to other Python dependency management tools (is that ok?)