### PR TITLE
Adjust code highlighting `bash` -> `console`

### DIFF
--- a/content/dependencies.md
+++ b/content/dependencies.md
@@ -106,24 +106,24 @@ commit hashes or Git tags.
 - Standard place to share Python packages.
 - Also mixed-language packages are possible wrapped in a Python layer.
 - Install a package:
-```
+```console
 $ pip install somepackage
 ```
 - Install a specific version:
-```
+```console
 $ pip install somepackage==1.2.3
 ```
 - Freeze the current environment into `requirements.txt`:
-```
+```console
 $ pip freeze > requirements.txt
 ```
 - Install all dependencies listed in `requirements.txt`:
-```
+```console
 $ pip install -r requirements.txt
 ```
 - Creating and sharing your own package: [https://packaging.python.org/tutorials/packaging-projects/](https://packaging.python.org/tutorials/packaging-projects/)
 - It is possible to pip install from GitHub or other places:
-```
+```console
 $ pip install git+https://github.com/anotheruser/anotherproject.git@sometag
 ```
 
@@ -143,48 +143,48 @@ $ pip install git+https://github.com/anotheruser/anotherproject.git@sometag
 - Allows you to create and share conda packages.
 - [Miniconda](https://docs.conda.io/en/latest/miniconda.html) is a lightweight alternative to [Anaconda](https://www.anaconda.com).
 - Install a package:
-```
+```console
 $ conda install somepackage
 ```
 - Install a specific version:
-```
+```console
 $ conda install somepackage=1.2.3
 ```
 - Create a new environment:
-```
+```console
 $ conda create --name myenvironment
 ```
 - Create a new environment from `requirements.txt`:
-```
+```console
 $ conda create --name myenvironment --file requirements.txt
 ```
 - On e.g. HPC systems where you don't have write access to central
   installation directory:
-```
+```console
 $ conda create --prefix /some/path/to/env
 ```
 - Activate a specific environment:
-```
+```console
 $ conda activate myenvironment
 ```
 - Deactivate current environment:
-```
+```console
 $ conda deactivate
 ```
 - List all environments:
-```
+```console
 $ conda info -e
 ```
 - Freeze the current environment into `requirements.txt`:
-```
+```console
 $ conda list --export > requirements.txt
 ```
 - Freeze the current environment into `environment.yml`:
-```
+```console
 $ conda env export > environment.yml
 ```
 - To clean unnecessary cached files (which grow quickly over time):
-```
+```console
 $ conda clean # needs one flag, add --help for available options
 ```
 
@@ -243,11 +243,11 @@ A step-by-step guide on how to contribute packages can be found in the
 - [Virtualenv](https://docs.python-guide.org/dev/virtualenvs/)
   - Example use:
   ```shell
-  # creating a new env
+  $ # creating a new env
   $ virtualenv myenvironment
   $ virtualenv --python=python3 myenvironment
   $ virtualenv /path/to/myenvironment
-  # activating env, installing package and deactivating
+  $ # activating env, installing package and deactivating
   $ source myenvironment/bin/activate
   $ pip install somepackage
   $ deactivate

--- a/content/docker.md
+++ b/content/docker.md
@@ -126,13 +126,13 @@ CMD /bin/bash
 
 We can build the image by running docker build in the word_count directory containing Dockerfile:
 
-```shell
+```console
 $ docker build -t word_count:0.1 .
 ```
 This will take a few minutes...
 
 Check if the image is created:
-```shell
+```console
 $ docker images
 
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
@@ -148,13 +148,13 @@ ubuntu              16.04               7aa3602ab41e        3 weeks ago         
 
 We can run a container using `docker run` command:
 
-```shell
+```console
 $ docker run -i -t --name wordcount word_count:0.1
 ```
 Note: Use -d to start a container in the background in a detached mode (to create long-running containers).
 
 We can now see the running container (in another terminal):
-```shell
+```console
 $ docker ps
 ```
 
@@ -168,12 +168,12 @@ $ docker ps
 
 **Sharing a host directory with container**
 
-  ```shell
+  ```console
 $ docker run -it --name my-directory-test -v <path-on-hostmachine>:/opt/data <image_name>
   ```
 
 **Anyone with this image can reproduce the results we have generated**
-  ```shell
+  ```console
 $ docker run -v <path-on-hostmachine/results_directory>:/opt/word_count/results word_count:0.1 snakemake -s Snakefile_all
   ```
 The `results_directory` folder will have the results of our word count example project.
@@ -186,12 +186,12 @@ We can also specify snakemake (or  any other command) as the default command to 
 - DockerHub - A platform to share Docker images.
 - Login to DockerHub:
 
- ```shell
+ ```console
 $ docker login
   ```
 - Push to DockerHub. The image name has to be in **youruser/yourimage** format:
  
- ```shell
+ ```console
 $ docker tag TAGID YOURUSER/word_count
 $ docker push docker.io/YOURUSER/word_count
   ```
@@ -199,12 +199,12 @@ $ docker push docker.io/YOURUSER/word_count
 - For proprietary/sensitive images private Docker registries can be used
 - Sometimes you don't want to push the image but you want to freeze it locally
 
- ```shell
+ ```console
 $ docker save word_count > word_count_0.1.tar
  ```
 
 and then you can reload it with
 
- ```shell
+ ```console
 $ docker load --input word_count_0.1.tar
  ```

--- a/content/environments.md
+++ b/content/environments.md
@@ -38,8 +38,8 @@ software packages from untrusted package repositories.
 #### Examples of useful Docker images
 
 1. Run a specific version of *Rstudio* 
-   ```shell
-   docker run --rm -p 8787:8787 -e PASSWORD=yourpasswordhere rocker/rstudio
+   ```console
+   $ docker run --rm -p 8787:8787 -e PASSWORD=yourpasswordhere rocker/rstudio
    ```
 
    Then open your browser to
@@ -49,15 +49,15 @@ software packages from untrusted package repositories.
    [https://hub.docker.com/r/rocker/rstudio/tags](https://hub.docker.com/r/rocker/rstudio/tags)
    and run for example
 
-   ```shell
-   docker run --rm -p 8787:8787 -e PASSWORD=yourpasswordhere rocker/rstudio:3.3
+   ```console
+   $ docker run --rm -p 8787:8787 -e PASSWORD=yourpasswordhere rocker/rstudio:3.3
    ```
 
 2. Run a specific version of *Anaconda3* from
    [https://hub.docker.com/r/continuumio/anaconda3](https://hub.docker.com/r/continuumio/anaconda3)
 
-   ```shell
-   docker run -i -t continuumio/anaconda3 /bin/bash
+   ```console
+   $ docker run -i -t continuumio/anaconda3 /bin/bash
    ```
 
    and similarly one can also pick an image for *Anaconda2* at
@@ -111,16 +111,16 @@ However, containers may also have some drawbacks:
    your DockerHub account. 
 3. Click on "Add new instance" - you now have a free Alpine Linux Virtual Machine in browser where you can build and run Docker containers
 4. Pull the hello-world image from DockerHub:
-   ```shell
-   docker pull hello-world
+   ```console
+   $ docker pull hello-world
    ```
 5. List local images:
-   ```shell
-   docker image ls
+   ```console
+   $ docker image ls
    ```
 6. Now create a new container from the image and run it:
-   ```shell
-   docker run hello-world
+   ```console
+   $ docker run hello-world
    ```  
    This should output "Hello from Docker!" followed by a description of what just happened:
    ```shell
@@ -134,12 +134,12 @@ However, containers may also have some drawbacks:
    ```
 7. The hello-world image can't do much more than this. For a more interesting 
    challenge, we can run bash in interactive mode using the ubuntu image from DockerHub. The following command automatically pulls the image before creating the container:
-   ```shell
-   docker run -it ubuntu bash
+   ```console
+   $ docker run -it ubuntu bash
    ```
    Notice that the command prompt changed - we are now "inside" a live container. We can double-check that we're indeed in an Ubuntu environment:
-   ```shell
-   cat /etc/os-release
+   ```console
+   $ cat /etc/os-release
    ```
 8. Exit the container by typing `exit`.
 9. Challenge: run an ubuntu container and make it print "Hello from Ubuntu!".

--- a/content/workflow-management.md
+++ b/content/workflow-management.md
@@ -76,7 +76,7 @@ In this example we wish to:
 
 Example (for one book only) - let us test this out:
 
-```
+```console
 $ python source/wordcount.py data/isles.txt processed_data/isles.dat
 $ python source/plotcount.py processed_data/isles.dat processed_data/isles.png
 $ python source/zipf_test.py processed_data/isles.dat
@@ -115,7 +115,7 @@ Imagine we have programmed a GUI with a nice interface with icons where you can 
 ## Solution 2: Manual steps
 
 It is not too much work:
-```
+```console
 $ python source/wordcount.py data/abyss.txt processed_data/abyss.dat
 $ python source/plotcount.py processed_data/abyss.dat processed_data/abyss.png
 
@@ -138,7 +138,7 @@ This is **imperative style**: first do this, then to that, then do that, finally
 ## Solution 3: Script
 
 Let's express it more compactly with a shell script (Bash). Let's call it `script.sh`:
-```
+```bash
 #!/usr/bin/env bash
 
 # loop over all books
@@ -152,7 +152,7 @@ python source/zipf_test.py processed_data/abyss.dat processed_data/isles.dat pro
 ```
 
 We can run it with:
-```
+```console
 $ bash script.sh
 ```
 
@@ -222,7 +222,7 @@ Snakefiles contain rules that relate targets (`output`)
 to dependencies (`input`) and commands (`shell`).
 Let's try it out. Since version 5.11 one needs to specify number 
 of cores (or jobs) using `-j`, `--jobs` or `--cores`:
-```
+```console
 $ snakemake --delete-all-output -j 1
 $ snakemake -j 1
 ```
@@ -232,7 +232,7 @@ let Snakemake figure out the series of steps to produce results
 (targets). Fun fact: Excel is also declarative, not imperative.
 
 Try running `snakemake` again and observe that and discuss why it refused to rerun all steps:
-```
+```console
 $ snakemake -j 1
 
 Building DAG of jobs...
@@ -243,7 +243,7 @@ Make a modification to a txt or a dat file and run `snakemake` again and discuss
 what you see. One way to modify files is to use the `touch` command which will
 only update its timestamp:
 
-```
+```console
 $ touch results/results.txt  # make it look like the file has been changed
 $ snakemake -j 1
 ```
@@ -290,7 +290,7 @@ using the `--dag` option, which will output the DAG in `dot` language.
 which can be installed by `conda install graphviz`). It's not necessary to 
 run this step yourself.
 
-```bash
+```console
 $ snakemake -j 1 --dag | dot -Tpng > dag.png
 ```
 Rules that have yet to be completed are indicated with solid outlines, while already completed rules are indicated with dashed outlines.
@@ -478,7 +478,7 @@ rule count_words:
     shell: 'python {input.wc} {input.book} {output} >> {log} 2>&1'
 ```    
 - Transferring your workflow to a cluster:
-```
+```console
 $ snakemake --archive myworkflow.tar.gz -j 1
 $ scp myworkflow.tar.gz <some-cluster>
 $ ssh <some-cluster>
@@ -505,7 +505,7 @@ $ snakemake -n --use-conda -j 1
 ```
 
   The workflow can now be executed by:
-```bash
+```console
 $ snakemake -j 100 --cluster-config cluster.json --cluster "sbatch -A {cluster.account} --mem={cluster.mem} -t {cluster.time} -c {threads}"
 ```
 


### PR DESCRIPTION
- Adjust code highlighting to current best practices, `bash` is
  scripts only, `console` is console sessions.

- Review: I think this is good to go most likely
